### PR TITLE
rdmc_helper: detect ssl module FIPS_mode with or without custom API bindings

### DIFF
--- a/src/rdmc.py
+++ b/src/rdmc.py
@@ -99,7 +99,7 @@ try:
     # enable fips mode if our special functions are available in _ssl and OS is
     # in FIPS mode
     FIPSSTR = ""
-    if Encryption.check_fips_mode_os() and not ssl.FIPS_mode():
+    if Encryption.check_fips_mode_os() and not Encryption.check_fips_mode_ssl():
         ssl.FIPS_mode_set(long(1))
         if ssl.FIPS_mode():
             FIPSSTR = "FIPS mode enabled using openssl version %s.\n" % ssl.OPENSSL_VERSION

--- a/src/rdmc_helper.py
+++ b/src/rdmc_helper.py
@@ -536,6 +536,24 @@ class Encryption(object):
                 fips = False
         return fips
 
+    @staticmethod
+    def check_fips_mode_ssl():
+        """Function to check for the SSL fips mode
+
+        Uses custom cpython ssl module API, if available. Otheriwse
+        probes using ctypes.cdll APIs.
+
+        :returns: returns True if FIPS mode is active, False otherwise
+
+        """
+        import ssl
+        if hasattr(ssl, 'FIPS_mode'):
+            return ssl.FIPS_mode()
+
+        from ctypes import cdll
+        libcrypto = cdll.LoadLibrary(ssl._ssl.__file__)
+        return libcrypto.FIPS_mode()
+
     def encrypt_file(self, filetxt, key):
         """ encrypt a file given a key
 


### PR DESCRIPTION
Fixes: https://github.com/HewlettPackard/python-redfish-utility/issues/25

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>