### PR TITLE
pyproject.toml: add triple quotes at the end of file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,4 @@ exclude = '''
   | build
   | dist
 )/
+'''


### PR DESCRIPTION
Hi,
ilorest fails to build from source in Debian (at least) 
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1022314

After adding triple quotes at the end of file, I verified that the problem is solved.

Kind Regards
