### PR TITLE
Fix import path to work also in the distros

### DIFF
--- a/src/extensions/BIOS COMMANDS/BiosDefaultsCommand.py
+++ b/src/extensions/BIOS COMMANDS/BiosDefaultsCommand.py
@@ -19,12 +19,20 @@
 
 from argparse import SUPPRESS, ArgumentParser
 
-from rdmc_helper import (
-    Encryption,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    ReturnCodes,
-)
+try:
+    from rdmc_helper import (
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        ReturnCodes,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        ReturnCodes,
+    )
 
 
 class BiosDefaultsCommand:

--- a/src/extensions/BIOS COMMANDS/BootOrderCommand.py
+++ b/src/extensions/BIOS COMMANDS/BootOrderCommand.py
@@ -24,16 +24,30 @@ from argparse import SUPPRESS, ArgumentParser
 from functools import reduce
 
 import six
-from rdmc import RdmcCommand
-from rdmc_helper import (
-    UI,
-    BootOrderMissingEntriesError,
-    Encryption,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    InvalidOrNothingChangedSettingsError,
-    ReturnCodes,
-)
+try:
+    from rdmc import RdmcCommand
+except ImportError:
+    from ilorest.rdmc import RdmcCommand
+try:
+    from rdmc_helper import (
+        UI,
+        BootOrderMissingEntriesError,
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidOrNothingChangedSettingsError,
+        ReturnCodes,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        UI,
+        BootOrderMissingEntriesError,
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidOrNothingChangedSettingsError,
+        ReturnCodes,
+    )
 
 
 class BootOrderCommand:

--- a/src/extensions/BIOS COMMANDS/IscsiConfigCommand.py
+++ b/src/extensions/BIOS COMMANDS/IscsiConfigCommand.py
@@ -22,14 +22,24 @@ import re
 from argparse import SUPPRESS, ArgumentParser
 
 import redfish.ris
-from rdmc_helper import (
-    BootOrderMissingEntriesError,
-    Encryption,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NicMissingOrConfigurationError,
-    ReturnCodes,
-)
+try:
+    from rdmc_helper import (
+        BootOrderMissingEntriesError,
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NicMissingOrConfigurationError,
+        ReturnCodes,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        BootOrderMissingEntriesError,
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NicMissingOrConfigurationError,
+        ReturnCodes,
+    )
 
 
 class IscsiConfigCommand:

--- a/src/extensions/BIOS COMMANDS/SetPasswordCommand.py
+++ b/src/extensions/BIOS COMMANDS/SetPasswordCommand.py
@@ -20,13 +20,22 @@
 import getpass
 from argparse import SUPPRESS, ArgumentParser
 
-from rdmc_helper import (
-    Encryption,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    ReturnCodes,
-    UnableToDecodeError,
-)
+try:
+    from rdmc_helper import (
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        ReturnCodes,
+        UnableToDecodeError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        Encryption,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        ReturnCodes,
+        UnableToDecodeError,
+    )
 
 
 class SetPasswordCommand:

--- a/src/extensions/COMMANDS/CommitCommand.py
+++ b/src/extensions/COMMANDS/CommitCommand.py
@@ -21,13 +21,22 @@ from argparse import SUPPRESS
 
 from redfish.ris.rmc_helper import NothingSelectedError
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    FailureDuringCommitError,
-    NoChangesFoundOrMadeError,
-    NoCurrentSessionEstablished,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        FailureDuringCommitError,
+        NoChangesFoundOrMadeError,
+        NoCurrentSessionEstablished,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        FailureDuringCommitError,
+        NoChangesFoundOrMadeError,
+        NoCurrentSessionEstablished,
+    )
 
 
 class CommitCommand:

--- a/src/extensions/COMMANDS/GetCommand.py
+++ b/src/extensions/COMMANDS/GetCommand.py
@@ -24,14 +24,26 @@ from argparse import ArgumentParser, SUPPRESS
 import redfish.ris
 from redfish.ris.utils import iterateandclear
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    UI,
-    NoContentsFoundForOperationError,
-    InvalidCommandLineError,
-)
-from rdmc_base_classes import HARDCODEDLIST
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        UI,
+        NoContentsFoundForOperationError,
+        InvalidCommandLineError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        UI,
+        NoContentsFoundForOperationError,
+        InvalidCommandLineError,
+    )
+try:
+    from rdmc_base_classes import HARDCODEDLIST
+except ImportError:
+    from ilorest.rdmc_base_classes import HARDCODEDLIST
 
 
 class GetCommand:

--- a/src/extensions/COMMANDS/InfoCommand.py
+++ b/src/extensions/COMMANDS/InfoCommand.py
@@ -17,13 +17,24 @@
 # -*- coding: utf-8 -*-
 """ Info Command for RDMC """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    InfoMissingEntriesError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InfoMissingEntriesError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InfoMissingEntriesError,
+    )
 
-from rdmc_base_classes import HARDCODEDLIST
+try:
+    from rdmc_base_classes import HARDCODEDLIST
+except ImportError:
+    from ilorest.rdmc_base_classes import HARDCODEDLIST
+
 from argparse import ArgumentParser, SUPPRESS
 
 

--- a/src/extensions/COMMANDS/ListCommand.py
+++ b/src/extensions/COMMANDS/ListCommand.py
@@ -17,11 +17,18 @@
 # -*- coding: utf-8 -*-
 """ List Command for RDMC """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+    )
 
 from argparse import ArgumentParser, SUPPRESS
 

--- a/src/extensions/COMMANDS/LoadCommand.py
+++ b/src/extensions/COMMANDS/LoadCommand.py
@@ -31,20 +31,37 @@ from six.moves import queue
 import redfish.ris
 
 from redfish.ris.rmc_helper import LoadSkipSettingError
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileFormattingError,
-    NoChangesFoundOrMadeError,
-    InvalidFileInputError,
-    NoDifferencesFoundError,
-    MultipleServerConfigError,
-    InvalidMSCfileInputError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileFormattingError,
+        NoChangesFoundOrMadeError,
+        InvalidFileInputError,
+        NoDifferencesFoundError,
+        MultipleServerConfigError,
+        InvalidMSCfileInputError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileFormattingError,
+        NoChangesFoundOrMadeError,
+        InvalidFileInputError,
+        NoDifferencesFoundError,
+        MultipleServerConfigError,
+        InvalidMSCfileInputError,
+        Encryption,
+    )
 
-from rdmc_base_classes import HARDCODEDLIST
+try:
+    from rdmc_base_classes import HARDCODEDLIST
+except ImportError:
+    from ilorest.rdmc_base_classes import HARDCODEDLIST
 
 # default file name
 __filename__ = "ilorest.json"

--- a/src/extensions/COMMANDS/LoginCommand.py
+++ b/src/extensions/COMMANDS/LoginCommand.py
@@ -22,14 +22,24 @@ import os
 import socket
 
 import redfish.ris
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    PathUnavailableError,
-    Encryption,
-    UsernamePasswordRequiredError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        PathUnavailableError,
+        Encryption,
+        UsernamePasswordRequiredError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        PathUnavailableError,
+        Encryption,
+        UsernamePasswordRequiredError,
+    )
 from redfish.rest.v1 import ServerDownOrUnreachableError
 
 

--- a/src/extensions/COMMANDS/LogoutCommand.py
+++ b/src/extensions/COMMANDS/LogoutCommand.py
@@ -20,7 +20,10 @@
 import sys
 
 from argparse import ArgumentParser, SUPPRESS
-from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS
+try:
+    from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS
+except ImportError:
+    from ilorest.rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS
 
 
 class LogoutCommand:

--- a/src/extensions/COMMANDS/PendingChangesCommand.py
+++ b/src/extensions/COMMANDS/PendingChangesCommand.py
@@ -24,13 +24,23 @@ from argparse import ArgumentParser, SUPPRESS
 
 import jsondiff
 
-from rdmc_base_classes import HARDCODEDLIST
+try:
+    from rdmc_base_classes import HARDCODEDLIST
+except ImportError:
+    from ilorest.rdmc_base_classes import HARDCODEDLIST
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+    )
 
 
 class PendingChangesCommand:

--- a/src/extensions/COMMANDS/REQUIREDCOMMANDS/ExitCommand.py
+++ b/src/extensions/COMMANDS/REQUIREDCOMMANDS/ExitCommand.py
@@ -19,7 +19,10 @@
 
 import sys
 
-from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS
+try:
+    from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS
+except ImportError:
+    from ilorest.rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS
 
 class ExitCommand():
     """ Exit class to handle exiting from interactive mode """

--- a/src/extensions/COMMANDS/REQUIREDCOMMANDS/HelpCommand.py
+++ b/src/extensions/COMMANDS/REQUIREDCOMMANDS/HelpCommand.py
@@ -20,8 +20,14 @@
 import sys
 
 from argparse import ArgumentParser
-from rdmc_base_classes import RdmcCommandBase, RdmcOptionParser
-from rdmc_helper import ReturnCodes, InvalidCommandLineError, InvalidCommandLineErrorOPTS
+try:
+    from rdmc_base_classes import RdmcCommandBase, RdmcOptionParser
+except ImportError:
+    from ilorest.rdmc_base_classes import RdmcCommandBase, RdmcOptionParser
+try:
+    from rdmc_helper import ReturnCodes, InvalidCommandLineError, InvalidCommandLineErrorOPTS
+except ImportError:
+    from ilorest.rdmc_helper import ReturnCodes, InvalidCommandLineError, InvalidCommandLineErrorOPTS
 
 
 class HelpCommand(RdmcCommandBase):

--- a/src/extensions/COMMANDS/ResultsCommand.py
+++ b/src/extensions/COMMANDS/ResultsCommand.py
@@ -24,12 +24,20 @@ from redfish.ris.resp_handler import ResponseHandler
 
 from redfish.ris.rmc_helper import EmptyRaiseForEAFP
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class ResultsCommand:

--- a/src/extensions/COMMANDS/SaveCommand.py
+++ b/src/extensions/COMMANDS/SaveCommand.py
@@ -23,14 +23,25 @@ from collections import OrderedDict
 
 import redfish.ris
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-    InvalidFileFormattingError,
-    Encryption,
-    iLORisCorruptionError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        InvalidFileFormattingError,
+        Encryption,
+        iLORisCorruptionError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        InvalidFileFormattingError,
+        Encryption,
+        iLORisCorruptionError,
+    )
+
 
 # default file name
 __filename__ = "ilorest.json"

--- a/src/extensions/COMMANDS/SelectCommand.py
+++ b/src/extensions/COMMANDS/SelectCommand.py
@@ -19,7 +19,10 @@
 
 from redfish.ris import NothingSelectedError
 
-from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS, LOGGER, Encryption
+try:
+    from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS, LOGGER, Encryption
+except ImportError:
+    from ilorest.rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS, LOGGER, Encryption
 
 
 class SelectCommand:

--- a/src/extensions/COMMANDS/SetCommand.py
+++ b/src/extensions/COMMANDS/SetCommand.py
@@ -19,13 +19,22 @@
 
 import redfish.ris
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    InvalidOrNothingChangedSettingsError,
-    UsernamePasswordRequiredError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidOrNothingChangedSettingsError,
+        UsernamePasswordRequiredError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidOrNothingChangedSettingsError,
+        UsernamePasswordRequiredError,
+    )
 
 from redfish.ris.rmc_helper import NothingSelectedError
 

--- a/src/extensions/COMMANDS/StatusCommand.py
+++ b/src/extensions/COMMANDS/StatusCommand.py
@@ -19,12 +19,20 @@
 
 from redfish.ris.utils import merge_dict
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-    NoCurrentSessionEstablished,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        NoCurrentSessionEstablished,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        NoCurrentSessionEstablished,
+    )
 
 
 class StatusCommand:

--- a/src/extensions/COMMANDS/TypesCommand.py
+++ b/src/extensions/COMMANDS/TypesCommand.py
@@ -17,11 +17,18 @@
 # -*- coding: utf-8 -*-
 """ Types Command for RDMC """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+    )
 
 
 class TypesCommand:

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/AdvancedPmmConfigCommand.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/AdvancedPmmConfigCommand.py
@@ -21,14 +21,25 @@ from __future__ import absolute_import  # verify if python3 libs can handle
 from copy import deepcopy
 from argparse import Action, REMAINDER
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    LOGGER,
-    NoChangesFoundOrMadeError,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+        NoChangesFoundOrMadeError,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+        NoChangesFoundOrMadeError,
+        NoContentsFoundForOperationError,
+    )
+
 
 from .lib.DisplayHelpers import DisplayHelpers
 from .lib.Mapper import Mapper

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/ApplyPmemConfigCommand.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/ApplyPmemConfigCommand.py
@@ -19,14 +19,24 @@
 from __future__ import absolute_import
 from copy import deepcopy
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    LOGGER,
-    NoChangesFoundOrMadeError,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+        NoChangesFoundOrMadeError,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+        NoChangesFoundOrMadeError,
+        NoContentsFoundForOperationError,
+    )
 
 from .lib.DisplayHelpers import DisplayHelpers
 from .lib.RestHelpers import RestHelpers

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/ClearPendingConfigCommand.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/ClearPendingConfigCommand.py
@@ -18,14 +18,24 @@
 """Command to clear pending tasks"""
 from __future__ import absolute_import
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    NoChangesFoundOrMadeError,
-    LOGGER,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        NoChangesFoundOrMadeError,
+        LOGGER,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        NoChangesFoundOrMadeError,
+        LOGGER,
+    )
 from .lib.RestHelpers import RestHelpers
 
 

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/DisplaySecurityStateCommand.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/DisplaySecurityStateCommand.py
@@ -24,20 +24,36 @@ import sys
 import json
 import os
 import time
-import versioning
-from config.rdmc_config import RdmcConfig
+try:
+    import versioning
+except ImportError:
+    from ilorest import versioning
+try:
+    from config.rdmc_config import RdmcConfig
+except ImportError:
+    from ilorest.config.rdmc_config import RdmcConfig
 from tabulate import tabulate
 
 from argparse import ArgumentParser
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    NoChangesFoundOrMadeError,
-    LOGGER,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        NoChangesFoundOrMadeError,
+        LOGGER,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        NoChangesFoundOrMadeError,
+        LOGGER,
+    )
 from .lib.RestHelpers import RestHelpers
 
 # ---------End of imports---------

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/ShowPmemCommand.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/ShowPmemCommand.py
@@ -22,13 +22,22 @@ import re
 from argparse import REMAINDER, Action
 
 from enum import Enum
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    LOGGER,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        LOGGER,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        LOGGER,
+    )
 
 from .lib.DisplayHelpers import DisplayHelpers, OutputFormats
 from .lib.Mapper import Mapper

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/ShowPmemPendingConfigCommand.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/ShowPmemPendingConfigCommand.py
@@ -19,13 +19,22 @@
 
 from __future__ import absolute_import
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    LOGGER,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+        NoContentsFoundForOperationError,
+    )
 
 from .lib.DisplayHelpers import DisplayHelpers, OutputFormats
 from .lib.Mapper import Mapper

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/ShowRecommendedConfigCommand.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/ShowRecommendedConfigCommand.py
@@ -20,13 +20,22 @@ from __future__ import absolute_import, division
 
 from collections import OrderedDict
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    LOGGER,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        LOGGER,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        LOGGER,
+    )
 
 from .lib.DisplayHelpers import DisplayHelpers, OutputFormats
 from .lib.Mapper import Mapper

--- a/src/extensions/PERSISTENT MEMORY COMMANDS/lib/DisplayHelpers.py
+++ b/src/extensions/PERSISTENT MEMORY COMMANDS/lib/DisplayHelpers.py
@@ -20,7 +20,10 @@ from __future__ import absolute_import
 
 from enum import Enum
 from tabulate import tabulate
-from rdmc_helper import LOGGER, UI
+try:
+    from rdmc_helper import LOGGER, UI
+except ImportError:
+    from ilorest.rdmc_helper import LOGGER, UI
 
 
 class OutputFormats(Enum):

--- a/src/extensions/RAW COMMANDS/RawDeleteCommand.py
+++ b/src/extensions/RAW COMMANDS/RawDeleteCommand.py
@@ -22,12 +22,20 @@ import json
 
 from argparse import ArgumentParser
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+    )
 
 
 class RawDeleteCommand:

--- a/src/extensions/RAW COMMANDS/RawGetCommand.py
+++ b/src/extensions/RAW COMMANDS/RawGetCommand.py
@@ -24,12 +24,20 @@ from argparse import ArgumentParser, SUPPRESS
 
 import redfish
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class RawGetCommand:

--- a/src/extensions/RAW COMMANDS/RawHeadCommand.py
+++ b/src/extensions/RAW COMMANDS/RawHeadCommand.py
@@ -24,12 +24,20 @@ from argparse import ArgumentParser, SUPPRESS
 
 import redfish
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class RawHeadCommand:

--- a/src/extensions/RAW COMMANDS/RawPatchCommand.py
+++ b/src/extensions/RAW COMMANDS/RawPatchCommand.py
@@ -27,14 +27,24 @@ from argparse import ArgumentParser, SUPPRESS
 
 from argparse import ArgumentParser
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidFileFormattingError,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileInputError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidFileFormattingError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidFileFormattingError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        Encryption,
+    )
 
 
 class RawPatchCommand:

--- a/src/extensions/RAW COMMANDS/RawPostCommand.py
+++ b/src/extensions/RAW COMMANDS/RawPostCommand.py
@@ -25,14 +25,24 @@ from collections import OrderedDict
 
 from argparse import ArgumentParser
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileInputError,
-    InvalidFileFormattingError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        InvalidFileFormattingError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        InvalidFileFormattingError,
+        Encryption,
+    )
 
 
 class RawPostCommand:

--- a/src/extensions/RAW COMMANDS/RawPutCommand.py
+++ b/src/extensions/RAW COMMANDS/RawPutCommand.py
@@ -25,14 +25,24 @@ from collections import OrderedDict
 
 from argparse import ArgumentParser
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileInputError,
-    InvalidFileFormattingError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        InvalidFileFormattingError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        InvalidFileFormattingError,
+        Encryption,
+    )
 
 
 class RawPutCommand:

--- a/src/extensions/SMART ARRAY COMMANDS/ClearControllerConfigCommand.py
+++ b/src/extensions/SMART ARRAY COMMANDS/ClearControllerConfigCommand.py
@@ -17,12 +17,20 @@
 # -*- coding: utf-8 -*-
 """ Clear Controller Configuration Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class ClearControllerConfigCommand:

--- a/src/extensions/SMART ARRAY COMMANDS/CreateLogicalDriveCommand.py
+++ b/src/extensions/SMART ARRAY COMMANDS/CreateLogicalDriveCommand.py
@@ -19,14 +19,22 @@
 
 from argparse import RawDescriptionHelpFormatter
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-    InvalidSmartArrayConfigurationError,
-)
-
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        InvalidSmartArrayConfigurationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        InvalidSmartArrayConfigurationError,
+    )
 
 class CreateLogicalDriveCommand:
     """Create logical drive command"""

--- a/src/extensions/SMART ARRAY COMMANDS/DeleteLogicalDriveCommand.py
+++ b/src/extensions/SMART ARRAY COMMANDS/DeleteLogicalDriveCommand.py
@@ -19,13 +19,22 @@
 
 from six.moves import input
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
 
 
 class DeleteLogicalDriveCommand:

--- a/src/extensions/SMART ARRAY COMMANDS/DriveSanitizeCommand.py
+++ b/src/extensions/SMART ARRAY COMMANDS/DriveSanitizeCommand.py
@@ -17,14 +17,22 @@
 # -*- coding: utf-8 -*-
 """ Drive Erase/ Sanitize Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-    NoContentsFoundForOperationError,
-)
-
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        NoContentsFoundForOperationError,
+    )
 
 class DriveSanitizeCommand:
     """Drive erase/sanitize command"""

--- a/src/extensions/SMART ARRAY COMMANDS/FactoryResetControllerCommand.py
+++ b/src/extensions/SMART ARRAY COMMANDS/FactoryResetControllerCommand.py
@@ -17,12 +17,20 @@
 # -*- coding: utf-8 -*-
 """ Factory Reset Controller Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class FactoryResetControllerCommand:

--- a/src/extensions/SMART ARRAY COMMANDS/SmartArrayCommand.py
+++ b/src/extensions/SMART ARRAY COMMANDS/SmartArrayCommand.py
@@ -22,21 +22,36 @@ import json
 import redfish
 
 from argparse import ArgumentParser, SUPPRESS, RawDescriptionHelpFormatter
-from rdmc_base_classes import RdmcCommandBase, HARDCODEDLIST
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    IncompatableServerTypeError,
-    InvalidCommandLineErrorOPTS,
-    UI,
-)
+
+try:
+    from rdmc_base_classes import RdmcCommandBase, HARDCODEDLIST
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        IncompatableServerTypeError,
+        InvalidCommandLineErrorOPTS,
+        UI,
+    )
+except ImportError:
+    from ilorest.rdmc_base_classes import RdmcCommandBase, HARDCODEDLIST
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        IncompatableServerTypeError,
+        InvalidCommandLineErrorOPTS,
+        UI,
+    )
 from redfish.ris.resp_handler import ResponseHandler
 from redfish.ris.utils import iterateandclear
 
 __config_file__ = "smartarray_config.json"
 
-from rdmc_base_classes import HARDCODEDLIST
+try:
+    from rdmc_base_classes import HARDCODEDLIST
+except ImportError:
+    from ilorest.rdmc_base_classes import HARDCODEDLIST
 
 __subparsers__ = ["load", "save", "state"]
 

--- a/src/extensions/SMART NIC COMMANDS/SmartNicCommand.py
+++ b/src/extensions/SMART NIC COMMANDS/SmartNicCommand.py
@@ -20,16 +20,28 @@ import os
 import time
 from redfish.ris.ris import SessionExpired
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    IncompatibleiLOVersionError,
-    InvalidCommandLineErrorOPTS,
-    UI,
-    TimeOutError,
-    FirmwareUpdateError,
-    UploadError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        IncompatibleiLOVersionError,
+        InvalidCommandLineErrorOPTS,
+        UI,
+        TimeOutError,
+        FirmwareUpdateError,
+        UploadError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        IncompatibleiLOVersionError,
+        InvalidCommandLineErrorOPTS,
+        UI,
+        TimeOutError,
+        FirmwareUpdateError,
+        UploadError,
+    )
 
 
 class SmartNicCommand:

--- a/src/extensions/_hidden commands/AHSdiagCommand.py
+++ b/src/extensions/_hidden commands/AHSdiagCommand.py
@@ -25,12 +25,21 @@ from ctypes import c_char_p, c_ubyte, c_int, POINTER, create_string_buffer
 from redfish.hpilo.rishpilo import HpIlo
 import redfish.hpilo.risblobstore2 as risblobstore2
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    LOGGER,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        LOGGER,
+    )
+
 
 if os.name != "nt":
     from _ctypes import dlclose

--- a/src/extensions/_hidden commands/AutomaticTestingCommand.py
+++ b/src/extensions/_hidden commands/AutomaticTestingCommand.py
@@ -39,19 +39,36 @@ from six.moves.urllib.request import urlretrieve, urlopen
 
 from redfish.ris.rmc_helper import IloResponseError
 
-from rdmc_helper import (
-    ReturnCodes,
-    CommandNotEnabledError,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    InvalidOrNothingChangedSettingsError,
-    NoContentsFoundForOperationError,
-    NoChangesFoundOrMadeError,
-    IncompatibleiLOVersionError,
-    PathUnavailableError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        CommandNotEnabledError,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidOrNothingChangedSettingsError,
+        NoContentsFoundForOperationError,
+        NoChangesFoundOrMadeError,
+        IncompatibleiLOVersionError,
+        PathUnavailableError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        CommandNotEnabledError,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        InvalidOrNothingChangedSettingsError,
+        NoContentsFoundForOperationError,
+        NoChangesFoundOrMadeError,
+        IncompatibleiLOVersionError,
+        PathUnavailableError,
+    )
 
-from rdmc_base_classes import HARDCODEDLIST
+try:
+    from rdmc_base_classes import HARDCODEDLIST
+except ImportError:
+    from ilorest.rdmc_base_classes import HARDCODEDLIST
+
 
 __error_logfile__ = "automatictesting_error_logfile.log"
 __pass_fail__ = "passfail"

--- a/src/extensions/_hidden commands/GetInventoryCommand.py
+++ b/src/extensions/_hidden commands/GetInventoryCommand.py
@@ -22,12 +22,20 @@ from argparse import ArgumentParser, SUPPRESS
 
 from redfish.ris.resp_handler import ResponseHandler
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class GetInventoryCommand:

--- a/src/extensions/_hidden commands/HpGooeyCommand.py
+++ b/src/extensions/_hidden commands/HpGooeyCommand.py
@@ -36,17 +36,31 @@ from six import StringIO, BytesIO
 
 import redfish.hpilo.risblobstore2 as risblobstore2
 
-from rdmc_helper import (
-    ReturnCodes,
-    CommandNotEnabledError,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    StandardBlobErrorHandler,
-    InvalidFileInputError,
-    PartitionMoutingError,
-    BirthcertParseError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        CommandNotEnabledError,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        StandardBlobErrorHandler,
+        InvalidFileInputError,
+        PartitionMoutingError,
+        BirthcertParseError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        CommandNotEnabledError,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        StandardBlobErrorHandler,
+        InvalidFileInputError,
+        PartitionMoutingError,
+        BirthcertParseError,
+        Encryption,
+    )
+
 
 if os.name == "nt":
     import win32api

--- a/src/extensions/_hidden commands/ISToolCommand.py
+++ b/src/extensions/_hidden commands/ISToolCommand.py
@@ -19,7 +19,10 @@
 
 from argparse import ArgumentParser
 
-from rdmc_helper import ReturnCodes, InvalidCommandLineError, InvalidCommandLineErrorOPTS
+try:
+    from rdmc_helper import ReturnCodes, InvalidCommandLineError, InvalidCommandLineErrorOPTS
+except ImportError:
+    from ilorest.rdmc_helper import ReturnCodes, InvalidCommandLineError, InvalidCommandLineErrorOPTS
 
 
 class ISToolCommand:

--- a/src/extensions/_hidden commands/MonolithCommand.py
+++ b/src/extensions/_hidden commands/MonolithCommand.py
@@ -22,12 +22,21 @@ import json
 from argparse import ArgumentParser
 from redfish.rest.containers import JSONEncoder
 from redfish.ris import UndefinedClientError
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileInputError,
-    UI,
-)
+
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        UI,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        UI,
+    )
 
 
 class MonolithCommand:

--- a/src/extensions/_hidden commands/SMBiosCommand.py
+++ b/src/extensions/_hidden commands/SMBiosCommand.py
@@ -25,13 +25,23 @@ from argparse import ArgumentParser
 
 import redfish.ris
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    IncompatibleiLOVersionError,
-    InvalidCommandLineError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        InvalidCommandLineError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        InvalidCommandLineError,
+    )
+
 
 __filename__ = "smbios.json"
 

--- a/src/extensions/_hidden commands/SecurityStatusCommand.py
+++ b/src/extensions/_hidden commands/SecurityStatusCommand.py
@@ -32,8 +32,14 @@ from redfish.hpilo.rishpilo import (
 from redfish.rest.connections import ChifDriverMissingOrNotFound
 from redfish.hpilo.risblobstore2 import BlobStore2, ChifDllMissingError
 
-from rdmc_base_classes import RdmcCommandBase
-from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS, Encryption
+try:
+    from rdmc_base_classes import RdmcCommandBase
+except ImportError:
+    from ilorest.rdmc_base_classes import RdmcCommandBase
+try:
+    from rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS, Encryption
+except ImportError:
+    from ilorest.rdmc_helper import ReturnCodes, InvalidCommandLineErrorOPTS, Encryption
 
 
 class SecurityStatusCommand(RdmcCommandBase):

--- a/src/extensions/iLO COMMANDS/CertificateCommand.py
+++ b/src/extensions/iLO COMMANDS/CertificateCommand.py
@@ -19,15 +19,27 @@
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    InvalidFileInputError,
-    IncompatibleiLOVersionError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
+
 
 __filename__ = "certificate.txt"
 

--- a/src/extensions/iLO COMMANDS/ClearRestApiStateCommand.py
+++ b/src/extensions/iLO COMMANDS/ClearRestApiStateCommand.py
@@ -19,13 +19,22 @@
 
 from argparse import ArgumentParser, SUPPRESS
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        NoContentsFoundForOperationError,
+    )
 
 
 class ClearRestApiStateCommand:

--- a/src/extensions/iLO COMMANDS/ComputeOpsManagementCommand.py
+++ b/src/extensions/iLO COMMANDS/ComputeOpsManagementCommand.py
@@ -19,17 +19,32 @@
 import time
 from argparse import RawDescriptionHelpFormatter
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    IncompatibleiLOVersionError,
-    NoCurrentSessionEstablished,
-    CloudConnectTimeoutError,
-    CloudConnectFailedError,
-    ProxyConfigFailedError,
-    AlreadyCloudConnectedError,
-    InvalidCommandLineError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        IncompatibleiLOVersionError,
+        NoCurrentSessionEstablished,
+        CloudConnectTimeoutError,
+        CloudConnectFailedError,
+        ProxyConfigFailedError,
+        AlreadyCloudConnectedError,
+        InvalidCommandLineError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        IncompatibleiLOVersionError,
+        NoCurrentSessionEstablished,
+        CloudConnectTimeoutError,
+        CloudConnectFailedError,
+        ProxyConfigFailedError,
+        AlreadyCloudConnectedError,
+        InvalidCommandLineError,
+    )
+
+
 from redfish.ris.ris import SessionExpired
 
 

--- a/src/extensions/iLO COMMANDS/DirectoryCommand.py
+++ b/src/extensions/iLO COMMANDS/DirectoryCommand.py
@@ -31,15 +31,27 @@ from argparse import (
 
 from redfish.ris.rmc_helper import IloResponseError, IdTokenError
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    IncompatibleiLOVersionError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    ResourceExists,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        IncompatibleiLOVersionError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        ResourceExists,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        IncompatibleiLOVersionError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        ResourceExists,
+        Encryption,
+    )
+
 
 __subparsers__ = ["ldap", "kerberos", "test"]
 

--- a/src/extensions/iLO COMMANDS/DisableIloFunctionalityCommand.py
+++ b/src/extensions/iLO COMMANDS/DisableIloFunctionalityCommand.py
@@ -21,14 +21,24 @@ import json
 
 from argparse import ArgumentParser, SUPPRESS
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    IncompatableServerTypeError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatableServerTypeError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatableServerTypeError,
+        Encryption,
+    )
 
 
 class DisableIloFunctionalityCommand:

--- a/src/extensions/iLO COMMANDS/ESKMCommand.py
+++ b/src/extensions/iLO COMMANDS/ESKMCommand.py
@@ -17,13 +17,22 @@
 # -*- coding: utf-8 -*-
 """ ESKM Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
 
 
 class ESKMCommand:

--- a/src/extensions/iLO COMMANDS/EthernetCommand.py
+++ b/src/extensions/iLO COMMANDS/EthernetCommand.py
@@ -38,17 +38,32 @@ from redfish.ris.rmc_helper import (
 )
 
 from redfish.ris.utils import diffdict
-from rdmc_helper import (
-    ReturnCodes,
-    RdmcError,
-    InvalidCommandLineError,
-    UI,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileInputError,
-    Encryption,
-    InvalidPropertyError,
-    NoDifferencesFoundError,
-)
+
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        RdmcError,
+        InvalidCommandLineError,
+        UI,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        Encryption,
+        InvalidPropertyError,
+        NoDifferencesFoundError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        RdmcError,
+        InvalidCommandLineError,
+        UI,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        Encryption,
+        InvalidPropertyError,
+        NoDifferencesFoundError,
+    )
+
 
 __eth_file__ = "eth.json"
 __subparsers__ = ["save", "load"]

--- a/src/extensions/iLO COMMANDS/FactoryDefaultsCommand.py
+++ b/src/extensions/iLO COMMANDS/FactoryDefaultsCommand.py
@@ -17,13 +17,22 @@
 # -*- coding: utf-8 -*-
 """ Factory Defaults Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
 
 
 class FactoryDefaultsCommand:

--- a/src/extensions/iLO COMMANDS/FirmwareIntegrityCheckCommand.py
+++ b/src/extensions/iLO COMMANDS/FirmwareIntegrityCheckCommand.py
@@ -20,15 +20,26 @@
 import time
 import datetime
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    IloLicenseError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    IncompatibleiLOVersionError,
-    TimeOutError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        IloLicenseError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        IncompatibleiLOVersionError,
+        TimeOutError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        IloLicenseError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        IncompatibleiLOVersionError,
+        TimeOutError,
+    )
 
 
 class FirmwareIntegrityCheckCommand:

--- a/src/extensions/iLO COMMANDS/FirmwareUpdateCommand.py
+++ b/src/extensions/iLO COMMANDS/FirmwareUpdateCommand.py
@@ -21,14 +21,24 @@ import time
 
 from redfish.ris.resp_handler import ResponseHandler
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    FirmwareUpdateError,
-    NoContentsFoundForOperationError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        FirmwareUpdateError,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        FirmwareUpdateError,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
 
 
 class FirmwareUpdateCommand:

--- a/src/extensions/iLO COMMANDS/IPProfilesCommand.py
+++ b/src/extensions/iLO COMMANDS/IPProfilesCommand.py
@@ -33,16 +33,28 @@ from six import StringIO, BytesIO
 import redfish
 from redfish.hpilo.risblobstore2 import BlobStore2
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileFormattingError,
-    UnableToDecodeError,
-    Encryption,
-    PathUnavailableError,
-    InvalidFileInputError,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileFormattingError,
+        UnableToDecodeError,
+        Encryption,
+        PathUnavailableError,
+        InvalidFileInputError,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileFormattingError,
+        UnableToDecodeError,
+        Encryption,
+        PathUnavailableError,
+        InvalidFileInputError,
+        NoContentsFoundForOperationError,
+    )
 
 
 class IPProfilesCommand:

--- a/src/extensions/iLO COMMANDS/IloAccountsCommand.py
+++ b/src/extensions/iLO COMMANDS/IloAccountsCommand.py
@@ -25,16 +25,29 @@ from argparse import Action, RawDescriptionHelpFormatter
 from redfish.ris.ris import SessionExpired
 from redfish.ris.rmc_helper import IdTokenError
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    ResourceExists,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    IncompatibleiLOVersionError,
-    Encryption,
-    InvalidFileInputError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        ResourceExists,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        Encryption,
+        InvalidFileInputError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        ResourceExists,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        Encryption,
+        InvalidFileInputError,
+    )
+
 
 __subparsers__ = ["add", "modify", "changepass", "delete", "addcert", "deletecert"]
 

--- a/src/extensions/iLO COMMANDS/IloBackupRestoreCommand.py
+++ b/src/extensions/iLO COMMANDS/IloBackupRestoreCommand.py
@@ -18,15 +18,26 @@
 """ Factory Defaults Command for rdmc """
 import os
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    InvalidFileInputError,
-    Encryption,
-    UploadError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+        Encryption,
+        UploadError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+        Encryption,
+        UploadError,
+    )
 
 
 class IloBackupRestoreCommand:

--- a/src/extensions/iLO COMMANDS/IloFederationCommand.py
+++ b/src/extensions/iLO COMMANDS/IloFederationCommand.py
@@ -25,16 +25,28 @@ from argparse import Action, RawDescriptionHelpFormatter
 from redfish.ris.ris import SessionExpired
 from redfish.ris.rmc_helper import IdTokenError
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    ResourceExists,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    IncompatibleiLOVersionError,
-    UsernamePasswordRequiredError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        ResourceExists,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        UsernamePasswordRequiredError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        ResourceExists,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        UsernamePasswordRequiredError,
+        Encryption,
+    )
 
 __subparsers__ = ["add", "modify", "changekey", "delete"]
 

--- a/src/extensions/iLO COMMANDS/IloLicenseCommand.py
+++ b/src/extensions/iLO COMMANDS/IloLicenseCommand.py
@@ -17,12 +17,20 @@
 # -*- coding: utf-8 -*-
 """ Add License Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class IloLicenseCommand:

--- a/src/extensions/iLO COMMANDS/IloResetCommand.py
+++ b/src/extensions/iLO COMMANDS/IloResetCommand.py
@@ -19,13 +19,22 @@
 
 from redfish.ris.rmc_helper import IloResponseError
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        Encryption,
+    )
 
 
 class IloResetCommand:

--- a/src/extensions/iLO COMMANDS/OneButtonEraseCommand.py
+++ b/src/extensions/iLO COMMANDS/OneButtonEraseCommand.py
@@ -25,14 +25,25 @@ from collections import OrderedDict
 import colorama
 from six.moves import input
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    IncompatibleiLOVersionError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
+
 
 CURSOR_UP_ONE = "\x1b[1A"
 ERASE_LINE = "\x1b[2K"

--- a/src/extensions/iLO COMMANDS/RebootCommand.py
+++ b/src/extensions/iLO COMMANDS/RebootCommand.py
@@ -23,13 +23,22 @@ import time
 from argparse import ArgumentParser, SUPPRESS
 from six.moves import input
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
 
 
 class RebootCommand:

--- a/src/extensions/iLO COMMANDS/SendTestCommand.py
+++ b/src/extensions/iLO COMMANDS/SendTestCommand.py
@@ -17,13 +17,22 @@
 # -*- coding: utf-8 -*-
 """ SendTest Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
 
 
 class SendTestCommand:

--- a/src/extensions/iLO COMMANDS/ServerCloneCommand.py
+++ b/src/extensions/iLO COMMANDS/ServerCloneCommand.py
@@ -38,18 +38,32 @@ from redfish.ris.rmc_helper import IloResponseError, IdTokenError, InstanceNotFo
 
 from six.moves import input
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidKeyError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileInputError,
-    NoChangesFoundOrMadeError,
-    NoContentsFoundForOperationError,
-    ResourceExists,
-    NoDifferencesFoundError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidKeyError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        NoChangesFoundOrMadeError,
+        NoContentsFoundForOperationError,
+        ResourceExists,
+        NoDifferencesFoundError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidKeyError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        NoChangesFoundOrMadeError,
+        NoContentsFoundForOperationError,
+        ResourceExists,
+        NoDifferencesFoundError,
+    )
 
 # default file name
 __DEFAULT__ = "<p/k>"

--- a/src/extensions/iLO COMMANDS/ServerInfoCommand.py
+++ b/src/extensions/iLO COMMANDS/ServerInfoCommand.py
@@ -22,12 +22,20 @@ from collections import OrderedDict
 
 import jsonpath_rw
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    UI,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        UI,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        UI,
+    )
 
 
 class ServerInfoCommand:

--- a/src/extensions/iLO COMMANDS/ServerStateCommand.py
+++ b/src/extensions/iLO COMMANDS/ServerStateCommand.py
@@ -17,13 +17,22 @@
 # -*- coding: utf-8 -*-
 """ Server State Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
 
 
 class ServerStateCommand:

--- a/src/extensions/iLO COMMANDS/ServerlogsCommand.py
+++ b/src/extensions/iLO COMMANDS/ServerlogsCommand.py
@@ -36,23 +36,43 @@ import redfish.hpilo.risblobstore2 as risblobstore2
 from redfish.ris.utils import filter_output
 from redfish.rest.connections import SecurityStateError
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    UI,
-    InvalidKeyError,
-    InvalidMSCfileInputError,
-    InvalidCommandLineErrorOPTS,
-    InvalidFileInputError,
-    LOGGER,
-    InvalidCListFileError,
-    NoContentsFoundForOperationError,
-    IncompatibleiLOVersionError,
-    Encryption,
-    PartitionMoutingError,
-    MultipleServerConfigError,
-    UnabletoFindDriveError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        UI,
+        InvalidKeyError,
+        InvalidMSCfileInputError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        LOGGER,
+        InvalidCListFileError,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        Encryption,
+        PartitionMoutingError,
+        MultipleServerConfigError,
+        UnabletoFindDriveError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        UI,
+        InvalidKeyError,
+        InvalidMSCfileInputError,
+        InvalidCommandLineErrorOPTS,
+        InvalidFileInputError,
+        LOGGER,
+        InvalidCListFileError,
+        NoContentsFoundForOperationError,
+        IncompatibleiLOVersionError,
+        Encryption,
+        PartitionMoutingError,
+        MultipleServerConfigError,
+        UnabletoFindDriveError,
+    )
+
 
 if os.name == "nt":
     import win32api

--- a/src/extensions/iLO COMMANDS/SigRecomputeCommand.py
+++ b/src/extensions/iLO COMMANDS/SigRecomputeCommand.py
@@ -17,13 +17,22 @@
 # -*- coding: utf-8 -*-
 """ SigRecompute Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    IncompatibleiLOVersionError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        IncompatibleiLOVersionError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        IncompatibleiLOVersionError,
+    )
 
 
 class SigRecomputeCommand:

--- a/src/extensions/iLO COMMANDS/SingleSignOnCommand.py
+++ b/src/extensions/iLO COMMANDS/SingleSignOnCommand.py
@@ -18,13 +18,22 @@
 """ Single Sign On Command for rdmc """
 from argparse import RawDescriptionHelpFormatter
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+    )
 
 
 class SingleSignOnCommand:

--- a/src/extensions/iLO COMMANDS/UnifiedCertificateCommand.py
+++ b/src/extensions/iLO COMMANDS/UnifiedCertificateCommand.py
@@ -19,15 +19,27 @@
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    InvalidCommandLineErrorOPTS,
-    NoContentsFoundForOperationError,
-    InvalidFileInputError,
-    IncompatibleiLOVersionError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        InvalidCommandLineErrorOPTS,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
+
 
 __filename__ = "certificate.txt"
 

--- a/src/extensions/iLO COMMANDS/VirtualMediaCommand.py
+++ b/src/extensions/iLO COMMANDS/VirtualMediaCommand.py
@@ -17,14 +17,24 @@
 # -*- coding: utf-8 -*-
 """ Virtual Media Command for rdmc """
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineError,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    UI,
-    IloLicenseError,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        UI,
+        IloLicenseError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineError,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        UI,
+        IloLicenseError,
+    )
 
 
 class VirtualMediaCommand:

--- a/src/extensions/iLO REPOSITORY COMMANDS/DeleteComponentCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/DeleteComponentCommand.py
@@ -17,13 +17,22 @@
 # -*- coding: utf-8 -*-
 """ Delete Component Command for rdmc """
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+    )
 
 
 class DeleteComponentCommand:

--- a/src/extensions/iLO REPOSITORY COMMANDS/DownloadComponentCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/DownloadComponentCommand.py
@@ -25,15 +25,26 @@ from ctypes import c_char_p, c_int
 
 import redfish.hpilo.risblobstore2 as risblobstore2
 
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-    DownloadError,
-    InvalidFileInputError,
-    IncompatibleiLOVersionError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        DownloadError,
+        InvalidFileInputError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        DownloadError,
+        InvalidFileInputError,
+        IncompatibleiLOVersionError,
+        Encryption,
+    )
 
 
 def human_readable_time(seconds):

--- a/src/extensions/iLO REPOSITORY COMMANDS/FwpkgCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/FwpkgCommand.py
@@ -28,17 +28,30 @@ from ctypes import c_char_p, c_int, c_bool
 
 from redfish.hpilo.risblobstore2 import BlobStore2
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-    InvalidFileInputError,
-    UploadError,
-    TaskQueueError,
-    FirmwareUpdateError,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        InvalidFileInputError,
+        UploadError,
+        TaskQueueError,
+        FirmwareUpdateError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        InvalidFileInputError,
+        UploadError,
+        TaskQueueError,
+        FirmwareUpdateError,
+    )
 
 
 def _get_comp_type(payload):

--- a/src/extensions/iLO REPOSITORY COMMANDS/InstallSetCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/InstallSetCommand.py
@@ -23,15 +23,26 @@ from datetime import datetime
 
 from argparse import RawDescriptionHelpFormatter
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    Encryption,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-    NoContentsFoundForOperationError,
-    InvalidFileInputError,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        Encryption,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        NoContentsFoundForOperationError,
+        InvalidFileInputError,
+    )
 
 
 class InstallSetCommand:

--- a/src/extensions/iLO REPOSITORY COMMANDS/ListComponentCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/ListComponentCommand.py
@@ -19,12 +19,20 @@
 
 import json
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+    )
 
 
 class ListComponentCommand:

--- a/src/extensions/iLO REPOSITORY COMMANDS/MaintenanceWindowCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/MaintenanceWindowCommand.py
@@ -25,14 +25,24 @@ from random import randint
 
 from redfish.ris.rmc_helper import ValidationError
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    NoContentsFoundForOperationError,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-    Encryption,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        NoContentsFoundForOperationError,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        Encryption,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        NoContentsFoundForOperationError,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        Encryption,
+    )
 
 __subparsers__ = ["add", "delete"]
 

--- a/src/extensions/iLO REPOSITORY COMMANDS/MakeInstallSetCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/MakeInstallSetCommand.py
@@ -22,12 +22,20 @@ import json
 
 from six.moves import input
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+    )
 
 
 class MakeInstallSetCommand:

--- a/src/extensions/iLO REPOSITORY COMMANDS/UpdateTaskQueueCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/UpdateTaskQueueCommand.py
@@ -22,15 +22,26 @@ from argparse import RawDescriptionHelpFormatter
 
 from redfish.ris.rmc_helper import IdTokenError
 
-from rdmc_helper import (
-    IncompatibleiLOVersionError,
-    ReturnCodes,
-    NoContentsFoundForOperationError,
-    InvalidCommandLineErrorOPTS,
-    InvalidCommandLineError,
-    Encryption,
-    TaskQueueError,
-)
+try:
+    from rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        NoContentsFoundForOperationError,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        Encryption,
+        TaskQueueError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        IncompatibleiLOVersionError,
+        ReturnCodes,
+        NoContentsFoundForOperationError,
+        InvalidCommandLineErrorOPTS,
+        InvalidCommandLineError,
+        Encryption,
+        TaskQueueError,
+    )
 
 __subparsers__ = ["create"]
 

--- a/src/extensions/iLO REPOSITORY COMMANDS/UploadComponentCommand.py
+++ b/src/extensions/iLO REPOSITORY COMMANDS/UploadComponentCommand.py
@@ -44,16 +44,29 @@ from redfish.hpilo.rishpilo import (
 from redfish.hpilo.rishpilo import BlobReturnCodes
 from redfish.hpilo.risblobstore2 import BlobStore2, Blob2SecurityError
 from redfish.rest.connections import Blobstore2Connection
-from rdmc_helper import (
-    ReturnCodes,
-    InvalidCommandLineErrorOPTS,
-    Encryption,
-    UploadError,
-    InvalidCommandLineError,
-    IncompatibleiLOVersionError,
-    TimeOutError,
-    InvalidFileInputError,
-)
+
+try:
+    from rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        UploadError,
+        InvalidCommandLineError,
+        IncompatibleiLOVersionError,
+        TimeOutError,
+        InvalidFileInputError,
+    )
+except ImportError:
+    from ilorest.rdmc_helper import (
+        ReturnCodes,
+        InvalidCommandLineErrorOPTS,
+        Encryption,
+        UploadError,
+        InvalidCommandLineError,
+        IncompatibleiLOVersionError,
+        TimeOutError,
+        InvalidFileInputError,
+    )
 
 
 def human_readable_time(seconds):


### PR DESCRIPTION
<p>&mdash;&ndash;Synopsis of Commits Above&mdash;&ndash;</p>

<p><strong>Please fill out the following when submitting the PR</strong></p>

<h2 id="status">Status</h2>

<ul>
<li>[x] READY </li>
<li>[ ] IN-DEVELOPMENT </li>
<li>[ ] ON-HOLD</li>
</ul>

<h2 id="description">Description</h2>

<p>This patch fixes the import path in case the package is under "ilorest" and not under python root. This makes it possible to package python-redfish-utility in distros (like Debian where I maintain the package).

A previous patch was merged, this fixes the missing bits.</p>

<h2 id="before-status-can-be-set-to-ready-i-have-completed-at-least-one-of-the-following">Before Status can be set to READY I have completed at least ONE of the following:</h2>

<ul>
<li>[x] Check if documentation updates</li>
<li>[x] Check if example code updates</li>
<li>[x] Pylint static analysistests are passing above 9.0/10.0</li>
<li>[N/A] Unit tests added for any new functions/features (Not required yet)</li>
<li>[x] Automatic testing passed</li>
<li>[x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.</li>
</ul>
