### PR TITLE
Make extensions import always work

### DIFF
--- a/src/rdmc.py
+++ b/src/rdmc.py
@@ -241,11 +241,12 @@ class RdmcCommand(RdmcCommandBase):
         # import all extensions dynamically
         for name in extensions.classNames:
             pkgName, cName = name.rsplit(".", 1)
-            pkgName = "extensions" + pkgName
+            pkgName = ".extensions" + pkgName
+
             try:
                 if "__pycache__" not in pkgName and "Command" in cName:
                     self.commands_dict[cName] = getattr(
-                        importlib.import_module(pkgName), cName
+                        importlib.import_module(pkgName, __package__), cName
                     )()
                     sName = pkgName.split(".")[1]
                     self.add_command(cName, section=sName)


### PR DESCRIPTION
This makes importlib.importmodule() always work, not depending where the module is (using relative imports).

<p>&mdash;&ndash;Synopsis of Commits Above&mdash;&ndash;</p>

<p><strong>Please fill out the following when submitting the PR</strong></p>

<h2 id="status">Status</h2>

<ul>
<li>[x] READY </li>
<li>[ ] IN-DEVELOPMENT </li>
<li>[ ] ON-HOLD</li>
</ul>

<h2 id="description">Description</h2>

<p>As per subject: makes import of extensions always work.</p>

<h2 id="before-status-can-be-set-to-ready-i-have-completed-at-least-one-of-the-following">Before Status can be set to READY I have completed at least ONE of the following:</h2>

<ul>
<li>[ ] Check if documentation updates</li>
<li>[ ] Check if example code updates</li>
<li>[ ] Pylint static analysistests are passing above 9.0/10.0</li>
<li>[N/A] Unit tests added for any new functions/features (Not required yet)</li>
<li>[ ] Automatic testing passed</li>
<li>[x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.</li>
</ul>
