### PR TITLE
Add ilorestcommand entrypoint

### DIFF
--- a/src/rdmc.py
+++ b/src/rdmc.py
@@ -1166,7 +1166,7 @@ class RdmcCommand(RdmcCommandBase):
         return checkargs(cmdinstance.parser.parse_known_args(exarglist))
 
 
-if __name__ == "__main__":
+def ilorestcommand():
     # Initialization of main command class
     ARGUMENTS = sys.argv[1:]
 
@@ -1204,3 +1204,6 @@ if __name__ == "__main__":
 
     # Return code
     sys.exit(RDMC.retcode)
+
+if __name__ == "__main__":
+    ilorestcommand()


### PR DESCRIPTION
<p>&mdash;&ndash;Synopsis of Commits Above&mdash;&ndash;</p>

<p><strong>Please fill out the following when submitting the PR</strong></p>

<h2 id="status">Status</h2>

<ul>
<li>[x] READY </li>
<li>[ ] IN-DEVELOPMENT </li>
<li>[ ] ON-HOLD</li>
</ul>

<h2 id="description">Description</h2>

<p>This makes it possible to call rdmc.py from an external binary.
In Debian we use /usr/bin/ilorest that calls this new function, as rdmc.py isn't in /usr/bin and isn't executable. In /usr/bin/ilorest, we have:

#! /usr/bin/python3
# PBR Generated from 'console_scripts'

import sys

from ilorest.rdmc import ilorestcommand


if __name__ == "__main__":
    sys.exit(ilorestcommand())

which is generated by PBR (that we use for the Python packaging).
</p>

<h2 id="before-status-can-be-set-to-ready-i-have-completed-at-least-one-of-the-following">Before Status can be set to READY I have completed at least ONE of the following:</h2>

<ul>
<li>[ ] Check if documentation updates</li>
<li>[ ] Check if example code updates</li>
<li>[ ] Pylint static analysistests are passing above 9.0/10.0</li>
<li>[N/A] Unit tests added for any new functions/features (Not required yet)</li>
<li>[ ] Automatic testing passed</li>
<li>[x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.</li>
</ul>
