### PR TITLE
Fix various Python 3 syntax errors

### DIFF
--- a/ilorest/extensions/RAW_COMMANDS/RawPatchCommand.py
+++ b/ilorest/extensions/RAW_COMMANDS/RawPatchCommand.py
@@ -122,7 +122,7 @@ class RawPatchCommand:
                 )
             )
 
-        elif all([re.match("^\/(\S+\/?)+$", key) for key in contentsholder]):
+        elif all([re.match("^/(S+/?)+$", key) for key in contentsholder]):
             for path, body in contentsholder.items():
                 results.append(
                     self.rdmc.app.patch_handler(

--- a/ilorest/extensions/RAW_COMMANDS/RawPostCommand.py
+++ b/ilorest/extensions/RAW_COMMANDS/RawPostCommand.py
@@ -133,7 +133,7 @@ class RawPostCommand:
                     service=options.service,
                 )
             )
-        elif all([re.match("^\/(\S+\/?)+$", key) for key in contentsholder]):
+        elif all([re.match("^/(S+/?)+$", key) for key in contentsholder]):
             for path, body in contentsholder.items():
                 results.append(
                     self.rdmc.app.post_handler(

--- a/ilorest/extensions/RAW_COMMANDS/RawPutCommand.py
+++ b/ilorest/extensions/RAW_COMMANDS/RawPutCommand.py
@@ -124,7 +124,7 @@ class RawPutCommand:
                     service=options.service,
                 )
             )
-        elif all([re.match("^\/(\S+\/?)+$", key) for key in contentsholder]):
+        elif all([re.match("^/(S+/?)+$", key) for key in contentsholder]):
             for path, body in contentsholder.items():
                 results.append(
                     self.rdmc.app.put_handler(

--- a/ilorest/extensions/_hidden_commands/HpGooeyCommand.py
+++ b/ilorest/extensions/_hidden_commands/HpGooeyCommand.py
@@ -545,7 +545,7 @@ class HpGooeyCommand:
         resp = self.rdmc.app.get_handler(path, silent=True, service=True, uncache=True)
         if resp.status == 200:
             data = resp.ori
-            if data is not b'':
+            if data != b'':
                 if "hpm" in path.lower():
                     self.rdmc.ui.printer("Successfully read HPM Birth Certificate.\n")
                 else:

--- a/ilorest/extensions/iLO_COMMANDS/ServerCloneCommand.py
+++ b/ilorest/extensions/iLO_COMMANDS/ServerCloneCommand.py
@@ -856,8 +856,8 @@ class ServerCloneCommand:
         typelist = []
         for _x in self._fdata:
             for _y in server_avail_types:
-                _x1 = re.split("#|\.", _x)
-                _y1 = re.split("#|\.", _y)
+                _x1 = re.split("#|.", _x)
+                _y1 = re.split("#|.", _y)
                 if _x1[0] == "":
                     _x1.pop(0)
                 if _y1[0] == "":

--- a/ilorest/extensions/iLO_COMMANDS/ServerInfoCommand.py
+++ b/ilorest/extensions/iLO_COMMANDS/ServerInfoCommand.py
@@ -359,7 +359,7 @@ class ServerInfoCommand:
                 if match.value.lower() == "absent":
                     arr = None
                     statepath = "/" + str(match.full_path).replace(".", "/")
-                    arr = re.split("[\[\]]", statepath)
+                    arr = re.split("[[]]", statepath)
                     if arr:
                         removedict = None
                         start = arr[0].split("/")


### PR DESCRIPTION
Installing ilorest under Python 3.12 in Debian unstable, a lot of syntax warning appear. Still remaining:

/usr/lib/python3/dist-packages/ilorest/extensions/iLO_COMMANDS/EthernetCommand.py:576: SyntaxWarning: list indices must be integers or slices, not str; perhaps you missed a comma?
  [self.rdmc.app.typepath.defs.oemhp]["DHCPv4"][
/usr/lib/python3/dist-packages/ilorest/extensions/iLO_COMMANDS/EthernetCommand.py:580: SyntaxWarning: list indices must be integers or slices, not str; perhaps you missed a comma?
  [self.rdmc.app.typepath.defs.oemhp]["DHCPv6"][


it'd be nice to fix these 2 as well...

